### PR TITLE
fixed version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "bloguito",
-  "version": "1.0"
+  "version": "1.1.0"
 }


### PR DESCRIPTION
Fixed error on ghost.io:
package.json: Value for field version, 1.0 does not match format: /^[0-9]+.[0-9]+[0-9+a-zA-Z.-]+$/
